### PR TITLE
Implement initial proxy logic and add Go workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,29 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.23'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...
+

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,25 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64

--- a/main.go
+++ b/main.go
@@ -1,0 +1,4 @@
+package main
+
+func main() {
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,12 +1,14 @@
 package proxy
 
 import (
-	"time"
-	"math/rand"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/rsa"
 	"log"
+	"time"
+	"math/big"
+	"crypto/tls"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"net/http"
 	"net/http/httputil"
 	"aegis/ca"

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,0 +1,103 @@
+package proxy
+
+import (
+	"time"
+	"math/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/rsa"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"aegis/ca"
+)
+
+type AegisProxy struct {
+	proxy	*httputil.ReverseProxy
+	caCert	tls.Certificate
+	caCertPool *x509.CertPool
+}
+
+// NewProxy initializes the Aegis proxy with CA credentials.
+func NewProxy() (*AegisProxy, error) {
+	// Load the root CA
+	caCert, err := ca.LoadRootCA()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a certificate pool with the CA certificate
+	caCertPool := x509.NewCertPool()
+	caCertPool.AddCert(caCert.Leaf)
+
+	// Configure the reverse proxy
+	director := func(req *http.Request) {
+		req.URL.Scheme = "https"
+		req.URL.Host = req.Host
+	}
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: caCertPool, // Trust our CA for outgoing connections
+		},
+	}
+	reverseProxy := &httputil.ReverseProxy{
+		Director: director,
+		Transport: transport,
+	}
+
+	return &AegisProxy{
+		proxy:	reverseProxy,
+		caCert:	*caCert,
+		caCertPool: caCertPool,
+	}, nil
+}
+
+// Start runs the proxy server on the specified address.
+func (a *AegisProxy) Start(addr string) error {
+	tlsConfig := &tls.Config{
+		GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return generateCert(info.ServerName, a.caCert)
+		},
+	}
+
+	server := &http.Server{
+		Addr:	addr,
+		Handler: a.proxy,
+		TLSConfig: tlsConfig,
+	}
+
+	log.Printf("Starting Aegis proxy on %s", addr)
+	return server.ListenAndServeTLS("","") // Certs handled dynamically
+}
+
+// generateCert creates a certificate for the requested domain, signed by the CA.
+func generateCert(domain string, caCert tls.Certificate) (*tls.Certificate, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: domain,
+		},
+		NotBefore: time.Now(),
+		NotAfter: time.Now().AddDate(1, 0, 0), // Valid for 1 year
+		KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames: []string{domain},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, caCert.Leaf, &priv.PublicKey, caCert.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	cert := &tls.Certificate{
+		Certificate: [][]byte{derBytes},
+		PrivateKey: priv,
+	}
+	return cert, nil
+}


### PR DESCRIPTION
Proxy handles the HTTPS traffic, using our CA for TLS interception. It sits between client and server, making it possible to intercept the requests and responses. It will be essential for blocking ads and trackers.