### PR TITLE
Implement initial filter logic

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -1,0 +1,17 @@
+package filter
+
+import "net/http"
+
+// Blocklist contains domain to block (e.g., ad servers).
+var Blocklist = map[string]bool{
+	"tbd": true,
+}
+
+// ApplyFilter checks if the request should be blocked based on the host.
+func ApplyFilter(w http.ResponseWriter, r *http.Request) bool {
+	if Blocklist[r.Host] {
+		http.Error(w, "Request blocked by Aegis", http.StatusForbidden)
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This implements the basic filtering logic to block certain domains and modifies the proxy.go with wrapping filter/filter.go's logic into AegisProxy's implemented http.Handler.

AegisProxy's http.Handler acts as a middleware to filter out traffic before passing it to the reverse proxy's handler that will do the actual traffic forwarding.